### PR TITLE
Fix JS source code showing while renaming a discussion

### DIFF
--- a/js/src/forum/components/RenameDiscussionModal.js
+++ b/js/src/forum/components/RenameDiscussionModal.js
@@ -49,7 +49,7 @@ export default class RenameDiscussionModal extends Modal {
 
     this.loading = true;
 
-    const title = this.newTitle;
+    const title = this.newTitle();
     const currentTitle = this.currentTitle;
 
     // If the title is different to what it was before, then save it. After the


### PR DESCRIPTION

https://user-images.githubusercontent.com/7406822/131597220-74e9aa40-6a60-4e46-a94e-73501e2f6204.mp4

