### PR TITLE
regression: fix slight transparency on forum header

### DIFF
--- a/less/common/mixins/header-background.less
+++ b/less/common/mixins/header-background.less
@@ -1,5 +1,5 @@
 .header-background() {
-  background: fade(@header-bg, 98%);
+  background: @header-bg;
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7406822/131599407-21626151-6353-4746-ab97-904df874fa5f.png)

This was fixed a long while back, but snuck back in in a theme CSS modification, I'd assume.

Worth fixing it here, like a later version of core did.